### PR TITLE
Update info.xml to denote as PayFlowPro

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -5,13 +5,13 @@
   <description>This extension provides an integration with PayPal's Payflow Pro service. It supports one time and recurring payments from CiviCRM.</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Seamus Lee</author>
-    <email>seamuslee001@gmail.com</email>
+    <author>Matthew Wire (MJW Consulting)</author>
+    <email>mjw@mjwconsult.co.uk</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">https://lab.civicrm.org</url>
+    <url desc="Main Extension Page">https://github.com/mjwconsult/civicrm-payflowpro</url>
     <url desc="Documentation">https://docs.civicrm.org/sysadmin/en/latest/setup/payment-processors/payflow/</url>
-    <url desc="Support">https://lab.civicrm.org</url>
+    <url desc="Support">https://github.com/mjwconsult/civicrm-payflowpro/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2025-07-31</releaseDate>


### PR DESCRIPTION
Updated the info.xml to point to this repository and change out the maintainer. We can update this later on as well when it gets moved to lab.c.o. Keep getting confused on if this is core or PayFlowPro.