### PR TITLE
Adjust JS for saved payment token to trigger the functions when loaded.

### DIFF
--- a/templates/CRM/Core/BillingBlockPayflowPro.tpl
+++ b/templates/CRM/Core/BillingBlockPayflowPro.tpl
@@ -1,5 +1,5 @@
 {crmScope extensionKey='payflowpro'}
-  {if $form.payment_token}
+  {if isset($form.payment_token)}
   <div class="crm-section {$form.payment_token.name}-section">
     <div class="label">
         {$form.payment_token.label}

--- a/templates/CRM/Core/BillingBlockPayflowPro.tpl
+++ b/templates/CRM/Core/BillingBlockPayflowPro.tpl
@@ -25,45 +25,54 @@
 {literal}
   <script>
 
-    // Re-prep form when we've loaded a new payproc via ajax or via webform
-    document.addEventListener('ajaxComplete', (event, xhr, settings) => {
-      if (CRM.payment.isAJAXPaymentForm(settings.url)) {
-        CRM.payment.debugging('payflowpro', 'triggered via ajax');
-        savedCardSelector();
-      }
-    });
-
-    document.addEventListener('DOMContentLoaded', (event) => {
-      console.log('DOMContentLoaded from payflowpro');
-      savedCardSelector();
-      updateCardFields();
-    });
-
-    function savedCardSelector() {
-      const paymentTokenElement = document.querySelector('select#payment_token');
-      paymentTokenElement.addEventListener('change', (event) => {
-        updateCardFields();
+    (function() {
+      // Re-prep form when we've loaded a new payproc via ajax or via webform
+      document.addEventListener('ajaxComplete', (event, xhr, settings) => {
+        if (CRM.payment.isAJAXPaymentForm(settings.url)) {
+          CRM.payment.debugging('payflowpro', 'triggered via ajax');
+          savedCardSelector();
+        }
       });
-    }
 
-    function updateCardFields() {
-      const paymentTokenElement = document.querySelector('select#payment_token');
-      if (paymentTokenElement.value == 0) {
-        document.querySelector('input#credit_card_number').classList.add('required');
-        document.querySelector('input#cvv2').classList.add('required');
-        document.querySelector('select#credit_card_exp_date_m').classList.add('required');
-        document.querySelector('select#credit_card_exp_date_Y').classList.add('required');
-        document.querySelector('div.credit_card_info-section').hidden = false;
+      // Run immediately if DOM is ready, otherwise wait
+      if (document.readyState !== 'loading') {
+        savedCardSelector();
+        updateCardFields();
+      } else {
+        document.addEventListener('DOMContentLoaded', (event) => {
+          console.log('DOMContentLoaded from payflowpro');
+          savedCardSelector();
+          updateCardFields();
+        });
       }
-      else {
-        document.querySelector('div.credit_card_info-section').hidden = true;
-        document.querySelector('input#credit_card_number').classList.remove('required');
-        document.querySelector('input#cvv2').classList.remove('required');
-        document.querySelector('select#credit_card_exp_date_m').classList.remove('required');
-        document.querySelector('select#credit_card_exp_date_Y').classList.remove('required');
-      }
-    }
 
+      function savedCardSelector() {
+        const paymentTokenElement = document.querySelector('select#payment_token');
+        paymentTokenElement.addEventListener('change', (event) => {
+          updateCardFields();
+        });
+      }
+
+      function updateCardFields() {
+        const paymentTokenElement = document.querySelector('select#payment_token');
+        if (paymentTokenElement.value == 0) {
+          document.querySelector('input#credit_card_number').classList.add('required');
+          document.querySelector('input#cvv2').classList.add('required');
+          document.querySelector('select#credit_card_exp_date_m').classList.add('required');
+          document.querySelector('select#credit_card_exp_date_Y').classList.add('required');
+          document.querySelector('div.credit_card_info-section').hidden = false;
+          document.querySelector('div.save_payment_token-section').hidden = false;
+        }
+        else {
+          document.querySelector('div.credit_card_info-section').hidden = true;
+          document.querySelector('div.save_payment_token-section').hidden = true;
+          document.querySelector('input#credit_card_number').classList.remove('required');
+          document.querySelector('input#cvv2').classList.remove('required');
+          document.querySelector('select#credit_card_exp_date_m').classList.remove('required');
+          document.querySelector('select#credit_card_exp_date_Y').classList.remove('required');
+        }
+      }
+    })();
   </script>
 {/literal}
 


### PR DESCRIPTION
I wasn't getting the JS to work when loading up a contribution payment after the payment token was saved. The card would show up, but when selecting the card, the standard CC fields would still show and be required.

This adds a check if the DOM is already loaded and if so just calls the functions, or then binds to the DOMContentLoaded event.